### PR TITLE
Various (suggestions)

### DIFF
--- a/scripts/test-one.sh
+++ b/scripts/test-one.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 if [ "$#" -lt 3 ];then
@@ -22,29 +22,29 @@ fi
 PROFILE=$1
 DATADIR=$2
 TYPE=$3
-CHROMOSOMES=""
+CHROMOSOMES=()
 
 if [ ! -z "$4" ]; then
-    CHROMOSOMES="--chromosomes $4"
+    CHROMOSOMES=(--chromosomes "$4")
 fi
 
-shift;shift;shift;shift
+shift 4
 
 FULLPATH=test-data/test-data-$DATADIR/
-OUT=out-${DATADIR}-${TYPE}
+OUT=out-$DATADIR-$TYPE
 
 nextflow run main.nf \
-    -profile $PROFILE \
+    -profile "$PROFILE" \
     --verbose \
-    $CHROMOSOMES \
-    --${TYPE}Dir $FULLPATH \
-    --reference  $FULLPATH/reference.fa \
-    --known      $FULLPATH/known.bed \
-    --outdir     $OUT \
+    "${CHROMOSOMES[@]}" \
+    --"${TYPE}Dir" "$FULLPATH" \
+    --reference    "$FULLPATH"/reference.fa \
+    --known        "$FULLPATH"/known.bed \
+    --outdir       "$OUT" \
     "$@"
 
-outbytes=$(cat $OUT/genotype/*{INDEL,SNP}*.vcf  | wc -c)
+outbytes=$(cat "$OUT"/genotype/*{INDEL,SNP}*.vcf  | wc -c)
 
-if [ $outbytes -lt 1000 ]; then
+if [ "$outbytes" -lt 1000 ]; then
     exit 1
 fi

--- a/scripts/travis-install-singularity.sh
+++ b/scripts/travis-install-singularity.sh
@@ -5,7 +5,6 @@ if [ -z "$SGT_VER" ]; then
     exit 0
 fi
 
-
 sudo apt-get update && sudo apt-get install -y wget git \
                                                     build-essential \
                                                     squashfs-tools \

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # Install Singularity, if needed
 ./scripts/travis-install-singularity.sh
 
 # Install Nextflow
-cd $HOME
+cd
 curl -fsSL https://get.nextflow.io | bash
 chmod +x nextflow
 sudo mv nextflow /usr/local/bin/

--- a/scripts/travis-merge.sh
+++ b/scripts/travis-merge.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Only auto merge develop branch
-if [ "$TRAVIS_BRANCH" != "develop" -o "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    exit 0;
+if [ "$TRAVIS_BRANCH"       != "develop" ] ||
+   [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    exit 0
 fi
 
 git config user.email "johan.viklund@nbis.se"

--- a/scripts/travis-runner.sh
+++ b/scripts/travis-runner.sh
@@ -1,21 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "INSTALL DEPS"
 sudo apt-get install squashfs-tools
 if ! ./scripts/travis-install.sh; then
-    echo "Failed in install"
-    exit 1;
+    echo "Failed in install" >&2
+    exit 1
 fi
 
 echo "SETUP TEST DATA"
 if ! ./scripts/setup_testdata.sh; then
-    echo "Failed to setup test data"
-    exit 1;
+    echo "Failed to setup test data" >&2
+    exit 1
 fi
 
 echo "RUN TRAVIS TEST"
 if ! ./scripts/travis-test.sh; then
-    echo "Test failure"
+    echo "Test failure" >&2
     exit 1
 fi
-

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -2,15 +2,14 @@
 set -xeuo pipefail
 
 function chrom_for() {
-    if [ "$1" == "tiny" ]; then
-        echo "chr38"
-    elif [ "$1" == "small" ]; then
-        echo "chr36,chr37,chr38,chrX"
-    fi
+    case $1 in
+	tiny)  echo chr38 ;;
+	small) echo chr36,chr37,chr38,chrX
+    esac
 }
 
 if [ -z "$PROFILE" ]; then
-    echo "No profile specified"
+    echo 'No profile specified' >&2
     exit 1
 fi
 
@@ -19,13 +18,11 @@ FAIL=0
 for D in tiny small; do
     C=$(chrom_for $D)
     for T in fastq bam; do
-        if ! ./scripts/test-one.sh $PROFILE $D $T $C; then
-            echo "FAIL: $PROFILE $D $T"
+        if ! ./scripts/test-one.sh "$PROFILE" "$D" "$T" "$C"; then
+            printf 'FAIL: %s %s %s\n' "$PROFILE" "$D" "$T" >&2
             FAIL=1
         fi
     done
 done
 
-if [ $FAIL -eq 1 ]; then
-    exit 1
-fi
+exit "$FAIL"


### PR DESCRIPTION
These are only suggestions. Also, the code is tested for syntax _only_.

* For bash scripts, use `#!/usr/bin/env bash` consistently.
* For scripts that don't need to be bash scripts, use `#!/bin/sh`.
* Fix quoting.
* Handle arrays (things that may be arrays, or should be arrays),
  especially in `setup_testdata.sh` and `test-one.sh`.
* Error messages to standard error stream.
* Safer parsing in `pull_singularity.sh`
* Minor other modifications.